### PR TITLE
Menu fixes to not allow selecting blank files

### DIFF
--- a/code/veccart/main.c
+++ b/code/veccart/main.c
@@ -40,7 +40,11 @@
 
 //Memory for the menu ROM and the running cartridge.
 //We keep both in memory so we can quickly exchange them when a reset has been detected.
-const int menuIndex = 0xfff; // fixed location in multicart.bin
+const int menuFileCount = 0xffe;         // fixed location in multicart.bin
+const int menuIndex = 0xfff;             // fixed location in multicart.bin
+const int menuFilePointers = 0x1000;     // 256 pointers to filenames
+const int menuFileStrings  = 0x1200;     // big chunk of ram to store filename strings
+
 char menuData[8*1024];
 char *romData=menuData;
 unsigned char parmRam[256];
@@ -137,7 +141,7 @@ void doChangeDir(char* dirname) {
 	}
 
 	romData=menuData;
-	loadListing(menuDir, &c_and_l.listing, menuIndex+1 , menuIndex+1+0x200, romData);
+	loadListing(menuDir, &c_and_l.listing, romData, menuFilePointers, menuFileStrings, menuFileCount);
 	menuData[menuIndex]=0; //reset selection
 
 	xprintf("Done listing for : %s\n", menuDir);
@@ -325,7 +329,7 @@ int main(void) {
 		strncpy(menuDir, "/roms", sizeof(menuDir));
 		f_mount(&FatFs, "", 0);
 		loadRom("/multicart.bin");
-		loadListing(menuDir, &c_and_l.listing, menuIndex+1 , menuIndex+1+0x200, romData);
+		loadListing(menuDir, &c_and_l.listing, romData, menuFilePointers, menuFileStrings, menuFileCount);
 
 		//Go emulate a ROM.
 		SYSCFG_MEMRMP=0x3; //mak ram at 0

--- a/code/veccart/menu.c
+++ b/code/veccart/menu.c
@@ -8,12 +8,12 @@
 
 //Get a listing of the roms in the 'roms/' directory and
 //poke them into the menu cartridge space
-void loadListing(char *fdir, dir_listing *listing, const int fnptrs, const int strptrs, char *romData) {
+void loadListing(char *fdir, dir_listing *listing, char *romData, const int fn_ptrs, const int str_ptrs, const int num_files_ptr) {
 	char buff[30];
 	char *name;
 
-	int ptrpos = fnptrs;  // fixed location in multicart.bin for 512 filename pointers (from &ptrpos ~ &strpos)
-	int strpos = strptrs; // filename data starts here
+	int ptrpos = fn_ptrs;  // fixed location in multicart.bin for 512 filename pointers (from &ptrpos ~ &strpos)
+	int strpos = str_ptrs; // filename data starts here
 
 	int i;
 	int is_dir;
@@ -61,6 +61,9 @@ void loadListing(char *fdir, dir_listing *listing, const int fnptrs, const int s
 	//finish with zero ptr
 	romData[ptrpos++]=0;
 	romData[ptrpos++]=0;
+
+	romData[num_files_ptr]=listing->num_files-1;
+
 	xprintf("Done.\n");
 }
 

--- a/code/veccart/menu.h
+++ b/code/veccart/menu.h
@@ -17,6 +17,6 @@ typedef struct {
 
 int removeExtension(char* filename, char* extension);
 void sortDirectory(char *fdir, dir_listing *listing); 
-void loadListing(char *fdir, dir_listing *listing, const int fnptrs, const int strptrs, char *romData); 
+void loadListing(char *fdir, dir_listing *listing, char *romData, const int fnptrs, const int strptrs, const int num_files_ptr); 
 
 #endif


### PR DESCRIPTION
### Problem

It's possible to select blank slots in the last page of the menu.

### Solution

This does a lot more last page detection steps, and adjusts the cursor to stay within the range of actual options.

### Steps to Test

Load up a directory of vec/bin files that is not a multiple of 4. The last page will have a blank spot in it. You should not be able to get to it. 

### References

Fixes #57 

---

### Contributor License Agreement

I, `the contributor`, agree to license my contributions to this project under the terms of the [GPL 3.0](https://www.gnu.org/licenses/gpl-3.0.html) or any later version.

>Please add your full legal name above, for this PR to be mergeable.  If you would prefer to sign a CLA via email, please request that.
