### PR TITLE
implement better brightness control, fixes #46

### DIFF
--- a/code/led-test/.gitignore
+++ b/code/led-test/.gitignore
@@ -1,2 +1,2 @@
-multicart.bin
-multicart.lst
+*.bin
+*.lst

--- a/code/led-test2/.gitignore
+++ b/code/led-test2/.gitignore
@@ -1,2 +1,2 @@
-multicart.bin
-multicart.lst
+*.bin
+*.lst

--- a/code/led-test2/.gitignore
+++ b/code/led-test2/.gitignore
@@ -1,0 +1,2 @@
+multicart.bin
+multicart.lst

--- a/code/led-test2/Dockerfile
+++ b/code/led-test2/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.9.4
+
+RUN apk add --no-cache --virtual .build-deps build-base wget \
+    && wget -O asm6809.tar.gz http://www.6809.org.uk/asm6809/dl/asm6809-2.12.tar.gz \
+    && tar -xvf asm6809.tar.gz -C /tmp \
+    && rm asm6809.tar.gz \
+    && cd /tmp/asm6809-2.12 \
+    && ./configure \
+    && make \
+    && make install \
+    && rm -rf /tmp/asm6809-2.12 \
+    && apk del .build-deps \
+    && apk add --no-cache make
+
+WORKDIR /build

--- a/code/led-test2/Makefile
+++ b/code/led-test2/Makefile
@@ -1,0 +1,24 @@
+# This uses asm6809 from
+# http://www.6809.org.uk/asm6809/dl/2.3/
+AS = asm6809
+
+default: docker
+
+docker-build: Dockerfile
+	docker build . -t asm6809
+
+all: docker
+
+docker:
+	docker run --rm -v `pwd`:/build -u `id -u ${USER}`:`id -g ${USER}` asm6809 make led-test2.bin
+
+led-test2.bin: led-test2.asm
+	$(AS)  -B -o $@ $^
+
+clean:
+	rm -f led-test2.bin
+
+copy: led-test.bin
+	sudo mount /dev/sde1 /mnt
+	sudo cp led-test2.bin /mnt
+	sudo umount /mnt

--- a/code/led-test2/led-test2.asm
+++ b/code/led-test2/led-test2.asm
@@ -1,0 +1,267 @@
+; Copyright (C) 2020 Brett Walach <technobly at gmail.com>
+; --------------------------------------------------------------------------
+; LED TEST demo
+;
+; This application demonstrates how to control the addressable LEDs
+; by seeding $7ff0 through $7ff9 with the LED colors, then calling
+; RPC function ID 7 (updateMulti) which writes out the data to all LEDs
+;
+; LED Colors
+; ----------
+; 0 = off
+; 1 = red
+; 2 = orange
+; 3 = yellow
+; 4 = green
+; 5 = cyan
+; 6 = blue
+; 7 = pink
+; 8 = magenta
+; 9 = white (Try not to use this one... it kind of draws a lot of power!)
+;
+; Original header follows:
+; --------------------------------------------------------------------------
+; Copyright (C) 2015 Jeroen Domburg <jeroen at spritesmods.com>
+;
+; This library is free software: you can redistribute it and/or modify
+; it under the terms of the GNU Lesser General Public License as published by
+; the Free Software Foundation, either version 3 of the License, or
+; (at your option) any later version.
+;
+; This library is distributed in the hope that it will be useful,
+; but WITHOUT ANY WARRANTY; without even the implied warranty of
+; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+; GNU Lesser General Public License for more details.
+;
+; You should have received a copy of the GNU Lesser General Public License
+; along with this library.  If not, see <http://www.gnu.org/licenses/>.
+;
+                    include  "vectrex.i"
+;***************************************************************************
+; DEFINES SECTION
+;***************************************************************************
+
+;***************************************************************************
+; USER RAM SECTION ($C880-$CBEA)
+;***************************************************************************
+user_ram            equ      $c880
+led_color           equ      $c880
+led_num             equ      $c881 ; counter to know when to switch colors (20ms * 5 = 100ms)
+led_brightness      equ      $c882 ; led brightness (0-31 values) << 3 bits (x8)
+led_bright_true     equ      $c883 ; set if we just updated led_brightness
+led0_addr           equ      $7ff0 ; start address of LED0
+ledb_addr           equ      $7ffe ; led brightness RPC value address
+;***************************************************************************
+; SYSTEM AREA of USER RAM SECTION ($CB00-$CBEA)
+;***************************************************************************
+rpcfn               equ      $cb00
+;***************************************************************************
+; HEADER SECTION
+;***************************************************************************
+                    org      0
+                    fcb      "g GCE 2020", $80            ; 'g' is copyright sign
+                    fdb      vextreme_tune1               ; catchy intro music to get stuck in your head
+                    fcb      $F6, $60, $20, -$42
+                    fcb      "LED TEST V2.0",$80          ; some game information ending with $80
+                    fcb      0                            ; end of game header
+;***************************************************************************
+; PROGRAM STARTS HERE
+;***************************************************************************
+main
+;***************************************************************************
+; RPC COPY START
+;***************************************************************************
+rpccopystart
+                    ldx      #rpcfndat
+                    ldy      #rpcfn
+rpccopyloop
+                    lda      ,x+
+                    sta      ,y+
+                    cmpx     #rpcfndatend
+                    bne      rpccopyloop
+;***************************************************************************
+; RPC COPY END
+;***************************************************************************
+init_vars
+                    lda      #1
+                    sta      led_color
+                    sta      led_bright_true
+                    lda      #15
+                    sta      led_brightness
+
+                    lda      #0                        ; 0 disables Joy 1 X
+                    sta      Vec_Joy_Mux_1_X           ;  |
+                    lda      #0                        ; 0 disables Joy 1 Y
+                    sta      Vec_Joy_Mux_1_Y           ;  |
+                    lda      #0                        ; 0 disables Joy 2 X & Y
+                    sta      Vec_Joy_Mux_2_X           ;  | saves a few hundred cycles
+                    sta      Vec_Joy_Mux_2_Y           ;  |
+;***************************************************************************
+; LED UPDATE FUNCTION START
+;***************************************************************************
+; update LED brightness from 0 to led_brightness (max 31), but this value must also be multiplied by 8
+led_brightness_start
+                    lda      led_brightness            ; LED desired brightness
+                    lsla                               ; (0-31) x8
+                    lsla                               ;  |
+                    lsla                               ;  |
+                    ldx      #ledb_addr                ; Load start address for LED0
+                    sta      ,x+                       ; Write brightness to LEDb memory
+                    lda      #8                        ; rpc call to update LED bightness, saved in $7ffe
+                    jmp      rpcfn                     ; Call, this will return to loop
+led_brightness_exit
+; update LEDs from 0 to led_num as led_color desired, off for remainder up to 9 (10 LEDs)
+led_color_start
+                    lda      #10                       ; Update all 10 LEDs
+                    sta      led_num                   ;  |
+                    clrb                               ; LED index counter
+                    lda      led_color                 ; LED desired color
+                    ldx      #led0_addr                ; Load start address for LED0
+led_color_loop
+                    cmpb     led_num                   ; Reached 0 - N LEDs yet?
+                    beq      led_off_start             ;  Yes, turn off the rest
+                    sta      ,x+                       ;  No, Write color to LED0 memory
+                    incb                               ; inc LEDx index counter
+                    bra      led_color_loop            ; Keep writing LEDx color
+led_off_start
+                    clra                               ; LED color that indicates OFF
+led_off_loop
+                    cmpb     #10                       ; Already wrote to last LED9 ?
+                    beq      led_color_exit            ;  Yes, all done, exit
+                    sta      ,x+                       ;  No, keep writing LEDx off color
+                    incb                               ; inc LEDx index counter
+                    bra      led_off_loop
+led_color_exit
+led_update
+                    lda      #7                        ; rpc call to update multiple LEDs, color saved in $7ff0 - $7ff9
+                    jmp      rpcfn                     ; Call
+led_update_exit
+;***************************************************************************
+; MAIN LOOP
+;***************************************************************************
+loop
+; Recal video stuff
+                    jsr      Wait_Recal
+                    jsr      Intensity_1F
+; Input handling
+                    jsr      Read_Btns
+                    anda     #$0F                      ; ignore joy2
+                    lsla                               ; convert to 2-byte index
+                    ldu      #button_routines
+                    leau     a,u                       ;fetch addr of string, page
+                    pulu     pc
+
+button_routines
+                    fdb      nobuttons                 ; 0x00 no buttons
+                    fdb      button1                   ; 0x01 b1
+                    fdb      button2                   ; 0x02 b2
+                    fdb      nobuttons                 ; 0x03 b2+b1
+                    fdb      button3                   ; 0x04 b3
+                    fdb      nobuttons                 ; 0x05 b3+b1
+                    fdb      nobuttons                 ; 0x06 b3+b2
+                    fdb      nobuttons                 ; 0x07 b3+b2+b1
+                    fdb      button4                   ; 0x08 b4
+                    fdb      nobuttons                 ; 0x09 b4+b1
+                    fdb      nobuttons                 ; 0x0A b4+b2
+                    fdb      nobuttons                 ; 0x0B b4+b2+b1
+                    fdb      nobuttons                 ; 0x0C b4+b3
+                    fdb      nobuttons                 ; 0x0D b4+b3+b1
+                    fdb      nobuttons                 ; 0x0E b4+b3+b2
+                    fdb      nobuttons                 ; 0x0F b4+b3+b2+b1
+
+nobuttons
+                    lda      led_bright_true           ; Did we just update brightness?
+                    cmpa     #1                        ;  |
+                    bne      nobuttons_exit            ;  No, just loop again
+                    clra                               ;  |
+                    sta      led_bright_true           ;  Yes, force a color update to refresh the LEDs
+                    jmp      led_color_start           ;  |
+nobuttons_exit
+                    jmp      loop
+
+button1
+                    lda      led_color
+                    cmpa     #0
+                    beq      button1_exit
+                    deca
+                    sta      led_color
+button1_exit
+                    jmp      led_color_start
+button2
+                    lda      led_color
+                    cmpa     #9
+                    beq      button2_exit
+                    inca
+                    sta      led_color
+button2_exit
+                    jmp      led_color_start
+button3
+                    lda      led_brightness
+                    cmpa     #0
+                    beq      led_brightness_jump
+                    deca
+                    sta      led_brightness
+                    bra      led_brightness_jump
+button4
+                    lda      led_brightness
+                    cmpa     #31
+                    beq      led_brightness_jump
+                    inca
+                    sta      led_brightness
+led_brightness_jump
+                    lda      #1
+                    sta      led_bright_true
+                    jmp      led_brightness_start
+
+;***************************************************************************
+; RPC FUNCTION START
+;***************************************************************************
+; Rpc function. Because this makes the cart unavailable, this
+; will copied to SRAM. Call as rpcfn.
+rpcfndat
+                    sta      $7fff
+rpcwaitloop
+                    lda      $0
+                    cmpa     # 'g'
+                    bne      rpcwaitloop
+                    lda      $1
+                    cmpa     # ' '
+                    bne      rpcwaitloop
+                    jmp      loop ;start address
+rpcfndatend
+;***************************************************************************
+; RPC FUNCTION END
+;***************************************************************************
+
+;***************************************************************************
+; SUBROUTINE SECTION
+;***************************************************************************
+
+;***************************************************************************
+; DATA SECTION
+;***************************************************************************
+
+; VEXTREME Tune Notes
+CS5                 equ      $1E
+F5                  equ      $22
+FS5                 equ      $23
+GS5                 equ      $25
+AS5                 equ      $27
+RST                 equ      $3F
+VIBENL              fcb      0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+FADE14              fdb      $0000,$2DDD,$DDDD,$B000,0,0,0,0
+; VEXTREME Intro Tune
+vextreme_tune1
+                    fdb      FADE14
+                    fdb      VIBENL
+                    fcb      FS5,8
+                    fcb      FS5,8
+                    fcb      FS5,8
+                    fcb      AS5,16
+                    fcb      GS5,16
+                    fcb      FS5,16
+                    fcb       F5,16
+                    fcb      CS5,8
+                    fcb      FS5,8
+                    fcb      RST,8
+                    fcb      0,$80 ; $80 is end marker for music, frequency is not played so 0

--- a/code/led-test2/readme.md
+++ b/code/led-test2/readme.md
@@ -1,0 +1,13 @@
+LED Test v2.0
+===
+
+This app tests the LED controls between Vectrex games and the VEXTREME cart.
+
+There is purposely no video displayed so that the noise from vectors remains silent.  This way you can more easily hear the effects of the LEDs and how it relates to issue #46
+
+1. Button 1 - Cycle down through colors, stopping at off (0)
+2. Button 2 - Cycle up through colors, stopping at white (9)
+3. Button 3 - Cycle down through brightness, stopping at off (0)
+4. Button 3 - Cycle up through brightness, stopping at max (31)
+
+:warning: **NOTE: Be careful NOT to leave the cart at MAX brightness with WHITE LEDs because it draws too much current.** :warning:

--- a/code/led-test2/vectrex.i
+++ b/code/led-test2/vectrex.i
@@ -1,0 +1,318 @@
+; this file is part of vectrex frogger, written by Christopher Salomon
+; in March-April 1998
+; all stuff contained here is public domain (?)
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; this file contains includes for vectrex BIOS functions and variables      ;
+; it was written by Bruce Tomlin, slighte changed by Christopher Salomon    ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+Vec_Snd_Shadow  equ     $C800   ;Shadow of sound chip registers (15 bytes)
+Vec_Btn_State   equ     $C80F   ;Current state of all joystick buttons
+Vec_Prev_Btns   equ     $C810   ;Previous state of all joystick buttons
+Vec_Buttons     equ     $C811   ;Current toggle state of all buttons
+Vec_Button_1_1  equ     $C812   ;Current toggle state of stick 1 button 1
+Vec_Button_1_2  equ     $C813   ;Current toggle state of stick 1 button 2
+Vec_Button_1_3  equ     $C814   ;Current toggle state of stick 1 button 3
+Vec_Button_1_4  equ     $C815   ;Current toggle state of stick 1 button 4
+Vec_Button_2_1  equ     $C816   ;Current toggle state of stick 2 button 1
+Vec_Button_2_2  equ     $C817   ;Current toggle state of stick 2 button 2
+Vec_Button_2_3  equ     $C818   ;Current toggle state of stick 2 button 3
+Vec_Button_2_4  equ     $C819   ;Current toggle state of stick 2 button 4
+Vec_Joy_Resltn  equ     $C81A   ;Joystick A/D resolution ($80=min $00=max)
+Vec_Joy_1_X     equ     $C81B   ;Joystick 1 left/right
+Vec_Joy_1_Y     equ     $C81C   ;Joystick 1 up/down
+Vec_Joy_2_X     equ     $C81D   ;Joystick 2 left/right
+Vec_Joy_2_Y     equ     $C81E   ;Joystick 2 up/down
+Vec_Joy_Mux     equ     $C81F   ;Joystick enable/mux flags (4 bytes)
+Vec_Joy_Mux_1_X equ     $C81F   ;Joystick 1 X enable/mux flag (=1)
+Vec_Joy_Mux_1_Y equ     $C820   ;Joystick 1 Y enable/mux flag (=3)
+Vec_Joy_Mux_2_X equ     $C821   ;Joystick 2 X enable/mux flag (=5)
+Vec_Joy_Mux_2_Y equ     $C822   ;Joystick 2 Y enable/mux flag (=7)
+Vec_Misc_Count  equ     $C823   ;Misc counter/flag byte, zero when not in use
+Vec_0Ref_Enable equ     $C824   ;Check0Ref enable flag
+Vec_Loop_Count  equ     $C825   ;Loop counter word (incremented in Wait_Recal)
+Vec_Brightness  equ     $C827   ;Default brightness
+Vec_Dot_Dwell   equ     $C828   ;Dot dwell time?
+Vec_Pattern     equ     $C829   ;Dot pattern (bits)
+Vec_Text_HW     equ     $C82A   ;Default text height and width
+Vec_Text_Height equ     $C82A   ;Default text height
+Vec_Text_Width  equ     $C82B   ;Default text width
+Vec_Str_Ptr     equ     $C82C   ;Temporary string pointer for Print_Str
+Vec_Counters    equ     $C82E   ;Six bytes of counters
+Vec_Counter_1   equ     $C82E   ;First  counter byte
+Vec_Counter_2   equ     $C82F   ;Second counter byte
+Vec_Counter_3   equ     $C830   ;Third  counter byte
+Vec_Counter_4   equ     $C831   ;Fourth counter byte
+Vec_Counter_5   equ     $C832   ;Fifth  counter byte
+Vec_Counter_6   equ     $C833   ;Sixth  counter byte
+Vec_RiseRun_Tmp equ     $C834   ;Temp storage word for rise/run
+Vec_Angle       equ     $C836   ;Angle for rise/run and rotation calculations
+Vec_Run_Index   equ     $C837   ;Index pair for run
+;*                       $C839   ;Pointer to copyright string during startup
+Vec_Rise_Index  equ     $C839   ;Index pair for rise
+;*                       $C83B   ;High score cold-start flag (=0 if valid)
+Vec_RiseRun_Len equ     $C83B   ;length for rise/run
+;*                       $C83C   ;temp byte
+Vec_Rfrsh       equ     $C83D   ;Refresh time (divided by 1.5MHz)
+Vec_Rfrsh_lo    equ     $C83D   ;Refresh time low byte
+Vec_Rfrsh_hi    equ     $C83E   ;Refresh time high byte
+Vec_Music_Work  equ     $C83F   ;Music work buffer (14 bytes, backwards?)
+Vec_Music_Wk_A  equ     $C842   ;        register 10
+;*                       $C843   ;        register 9
+;*                       $C844   ;        register 8
+Vec_Music_Wk_7  equ     $C845   ;        register 7
+Vec_Music_Wk_6  equ     $C846   ;        register 6
+Vec_Music_Wk_5  equ     $C847   ;        register 5
+;*                       $C848   ;        register 4
+;*                       $C849   ;        register 3
+;*                       $C84A   ;        register 2
+Vec_Music_Wk_1  equ     $C84B   ;        register 1
+;*                       $C84C   ;        register 0
+Vec_Freq_Table  equ     $C84D   ;Pointer to note-to-frequency table (normally $FC8D)
+Vec_Max_Players equ     $C84F   ;Maximum number of players for Select_Game
+Vec_Max_Games   equ     $C850   ;Maximum number of games for Select_Game
+Vec_ADSR_Table  equ     $C84F   ;Storage for first music header word (ADSR table)
+Vec_Twang_Table equ     $C851   ;Storage for second music header word ('twang' table)
+Vec_Music_Ptr   equ     $C853   ;Music data pointer
+Vec_Expl_ChanA  equ     $C853   ;Used by Explosion_Snd - bit for first channel used?
+Vec_Expl_Chans  equ     $C854   ;Used by Explosion_Snd - bits for all channels used?
+Vec_Music_Chan  equ     $C855   ;Current sound channel number for Init_Music
+Vec_Music_Flag  equ     $C856   ;Music active flag ($00=off $01=start $80=on)
+Vec_Duration    equ     $C857   ;Duration counter for Init_Music
+Vec_Music_Twang equ     $C858   ;3 word 'twang' table used by Init_Music
+Vec_Expl_1      equ     $C858   ;Four bytes copied from Explosion_Snd's U-reg parameters
+Vec_Expl_2      equ     $C859   ;
+Vec_Expl_3      equ     $C85A   ;
+Vec_Expl_4      equ     $C85B   ;
+Vec_Expl_Chan   equ     $C85C   ;Used by Explosion_Snd - channel number in use?
+Vec_Expl_ChanB  equ     $C85D   ;Used by Explosion_Snd - bit for second channel used?
+Vec_ADSR_Timers equ     $C85E   ;ADSR timers for each sound channel (3 bytes)
+Vec_Music_Freq  equ     $C861   ;Storage for base frequency of each channel (3 words)
+;*                       $C85E   ;Scratch 'score' storage for Display_Option (7 bytes)
+Vec_Expl_Flag   equ     $C867   ;Explosion_Snd initialization flag?
+;*               $C868...$C876   ;Unused?
+Vec_Expl_Timer  equ     $C877   ;Used by Explosion_Snd
+;*                       $C878   ;Unused?
+Vec_Num_Players equ     $C879   ;Number of players selected in Select_Game
+Vec_Num_Game    equ     $C87A   ;Game number selected in Select_Game
+Vec_Seed_Ptr    equ     $C87B   ;Pointer to 3-byte random number seed (=$C87D)
+Vec_Random_Seed equ     $C87D   ;Default 3-byte random number seed
+                                ;
+;*    $C880 - $CBEA is user RAM  ;
+                                ;
+Vec_Default_Stk equ     $CBEA   ;Default top-of-stack
+Vec_High_Score  equ     $CBEB   ;High score storage (7 bytes)
+Vec_SWI3_Vector equ     $CBF2   ;SWI2/SWI3 interrupt vector (3 bytes)
+Vec_SWI2_Vector equ     $CBF2   ;SWI2/SWI3 interrupt vector (3 bytes)
+Vec_FIRQ_Vector equ     $CBF5   ;FIRQ interrupt vector (3 bytes)
+Vec_IRQ_Vector  equ     $CBF8   ;IRQ interrupt vector (3 bytes)
+Vec_SWI_Vector  equ     $CBFB   ;SWI/NMI interrupt vector (3 bytes)
+Vec_NMI_Vector  equ     $CBFB   ;SWI/NMI interrupt vector (3 bytes)
+Vec_Cold_Flag   equ     $CBFE   ;Cold start flag (warm start if = $7321)
+                                ;
+VIA_port_b      equ     $D000   ;VIA port B data I/O register
+;*       0 sample/hold (0=enable  mux 1=disable mux)
+;*       1 mux sel 0
+;*       2 mux sel 1
+;*       3 sound BC1
+;*       4 sound BDIR
+;*       5 comparator input
+;*       6 external device (slot pin 35) initialized to input
+;*       7 /RAMP
+VIA_port_a      equ     $D001   ;VIA port A data I/O register (handshaking)
+VIA_DDR_b       equ     $D002   ;VIA port B data direction register (0=input 1=output)
+VIA_DDR_a       equ     $D003   ;VIA port A data direction register (0=input 1=output)
+VIA_t1_cnt_lo   equ     $D004   ;VIA timer 1 count register lo (scale factor)
+VIA_t1_cnt_hi   equ     $D005   ;VIA timer 1 count register hi
+VIA_t1_lch_lo   equ     $D006   ;VIA timer 1 latch register lo
+VIA_t1_lch_hi   equ     $D007   ;VIA timer 1 latch register hi
+VIA_t2_lo       equ     $D008   ;VIA timer 2 count/latch register lo (refresh)
+VIA_t2_hi       equ     $D009   ;VIA timer 2 count/latch register hi
+VIA_shift_reg   equ     $D00A   ;VIA shift register
+VIA_aux_cntl    equ     $D00B   ;VIA auxiliary control register
+;*       0 PA latch enable
+;*       1 PB latch enable
+;*       2 \                     110=output to CB2 under control of phase 2 clock
+;*       3  > shift register control     (110 is the only mode used by the Vectrex ROM)
+;*       4 /
+;*       5 0=t2 one shot                 1=t2 free running
+;*       6 0=t1 one shot                 1=t1 free running
+;*       7 0=t1 disable PB7 output       1=t1 enable PB7 output
+VIA_cntl        equ     $D00C   ;VIA control register
+;*       0 CA1 control     CA1 -> SW7    0=IRQ on low 1=IRQ on high
+;*       1 \
+;*       2  > CA2 control  CA2 -> /ZERO  110=low 111=high
+;*       3 /
+;*       4 CB1 control     CB1 -> NC     0=IRQ on low 1=IRQ on high
+;*       5 \
+;*       6  > CB2 control  CB2 -> /BLANK 110=low 111=high
+;*       7 /
+VIA_int_flags   equ     $D00D   ;VIA interrupt flags register
+;*               bit                             cleared by
+;*       0 CA2 interrupt flag            reading or writing port A I/O
+;*       1 CA1 interrupt flag            reading or writing port A I/O
+;*       2 shift register interrupt flag reading or writing shift register
+;*       3 CB2 interrupt flag            reading or writing port B I/O
+;*       4 CB1 interrupt flag            reading or writing port A I/O
+;*       5 timer 2 interrupt flag        read t2 low or write t2 high
+;*       6 timer 1 interrupt flag        read t1 count low or write t1 high
+;*       7 IRQ status flag               write logic 0 to IER or IFR bit
+VIA_int_enable  equ     $D00E   ;VIA interrupt enable register
+;*       0 CA2 interrupt enable
+;*       1 CA1 interrupt enable
+;*       2 shift register interrupt enable
+;*       3 CB2 interrupt enable
+;*       4 CB1 interrupt enable
+;*       5 timer 2 interrupt enable
+;*       6 timer 1 interrupt enable
+;*       7 IER set/clear control
+VIA_port_a_nohs equ     $D00F   ;VIA port A data I/O register (no handshaking)
+
+Cold_Start      equ     $F000   ;
+Warm_Start      equ     $F06C   ;
+Init_VIA        equ     $F14C   ;
+Init_OS_RAM     equ     $F164   ;
+Init_OS         equ     $F18B   ;
+Wait_Recal      equ     $F192   ;
+Set_Refresh     equ     $F1A2   ;
+DP_to_D0        equ     $F1AA   ;
+DP_to_C8        equ     $F1AF   ;
+Read_Btns_Mask  equ     $F1B4   ;
+Read_Btns       equ     $F1BA   ;
+Joy_Analog      equ     $F1F5   ;
+Joy_Digital     equ     $F1F8   ;
+Sound_Byte      equ     $F256   ;
+Sound_Byte_x    equ     $F259   ;
+Sound_Byte_raw  equ     $F25B   ;
+Clear_Sound     equ     $F272   ;
+Sound_Bytes     equ     $F27D   ;
+Sound_Bytes_x   equ     $F284   ;
+Do_Sound        equ     $F289   ;
+Do_Sound_x      equ     $F28C   ;
+Intensity_1F    equ     $F29D   ;
+Intensity_3F    equ     $F2A1   ;
+Intensity_5F    equ     $F2A5   ;
+Intensity_7F    equ     $F2A9   ;
+Intensity_a     equ     $F2AB   ;
+Dot_ix_b        equ     $F2BE   ;
+Dot_ix          equ     $F2C1   ;
+Dot_d           equ     $F2C3   ;
+Dot_here        equ     $F2C5   ;
+Dot_List        equ     $F2D5   ;
+Dot_List_Reset  equ     $F2DE   ;
+Recalibrate     equ     $F2E6   ;
+Moveto_x_7F     equ     $F2F2   ;
+Moveto_d_7F     equ     $F2FC   ;
+Moveto_ix_FF    equ     $F308   ;
+Moveto_ix_7F    equ     $F30C   ;
+Moveto_ix_a     equ     $F30E   ;
+Moveto_ix       equ     $F310   ;
+Moveto_d        equ     $F312   ;
+Reset0Ref_D0    equ     $F34A   ;
+Check0Ref       equ     $F34F   ;
+Reset0Ref       equ     $F354   ;
+Reset_Pen       equ     $F35B   ;
+Reset0Int       equ     $F36B   ;
+Print_Str_hwyx  equ     $F373   ;
+Print_Str_yx    equ     $F378   ;
+Print_Str_d     equ     $F37A   ;
+Print_List_hw   equ     $F385   ;
+Print_List      equ     $F38A   ;
+Print_List_chk  equ     $F38C   ;
+Print_Ships_x   equ     $F391   ;
+Print_Ships     equ     $F393   ;
+Mov_Draw_VLc_a  equ     $F3AD   ;count y x y x ...
+Mov_Draw_VL_b   equ     $F3B1   ;y x y x ...
+Mov_Draw_VLcs   equ     $F3B5   ;count scale y x y x ...
+Mov_Draw_VL_ab  equ     $F3B7   ;y x y x ...
+Mov_Draw_VL_a   equ     $F3B9   ;y x y x ...
+Mov_Draw_VL     equ     $F3BC   ;y x y x ...
+Mov_Draw_VL_d   equ     $F3BE   ;y x y x ...
+Draw_VLc        equ     $F3CE   ;count y x y x ...
+Draw_VL_b       equ     $F3D2   ;y x y x ...
+Draw_VLcs       equ     $F3D6   ;count scale y x y x ...
+Draw_VL_ab      equ     $F3D8   ;y x y x ...
+Draw_VL_a       equ     $F3DA   ;y x y x ...
+Draw_VL         equ     $F3DD   ;y x y x ...
+Draw_Line_d     equ     $F3DF   ;y x y x ...
+Draw_VLp_FF     equ     $F404   ;pattern y x pattern y x ... $01
+Draw_VLp_7F     equ     $F408   ;pattern y x pattern y x ... $01
+Draw_VLp_scale  equ     $F40C   ;scale pattern y x pattern y x ... $01
+Draw_VLp_b      equ     $F40E   ;pattern y x pattern y x ... $01
+Draw_VLp        equ     $F410   ;pattern y x pattern y x ... $01
+Draw_Pat_VL_a   equ     $F434   ;y x y x ...
+Draw_Pat_VL     equ     $F437   ;y x y x ...
+Draw_Pat_VL_d   equ     $F439   ;y x y x ...
+Draw_VL_mode    equ     $F46E   ;mode y x mode y x ... $01
+Print_Str       equ     $F495   ;
+Random_3        equ     $F511   ;
+Random          equ     $F517   ;
+Init_Music_Buf  equ     $F533   ;
+Clear_x_b       equ     $F53F   ;
+Clear_C8_RAM    equ     $F542   ;never used by GCE carts?
+Clear_x_256     equ     $F545   ;
+Clear_x_d       equ     $F548   ;
+Clear_x_b_80    equ     $F550   ;
+Clear_x_b_a     equ     $F552   ;
+Dec_3_Counters  equ     $F55A   ;
+Dec_6_Counters  equ     $F55E   ;
+Dec_Counters    equ     $F563   ;
+Delay_3         equ     $F56D   ;30 cycles
+Delay_2         equ     $F571   ;25 cycles
+Delay_1         equ     $F575   ;20 cycles
+Delay_0         equ     $F579   ;12 cycles
+Delay_b         equ     $F57A   ;5*B + 10 cycles
+Delay_RTS       equ     $F57D   ;5 cycles
+Bitmask_a       equ     $F57E   ;
+Abs_a_b         equ     $F584   ;
+Abs_b           equ     $F58B   ;
+Rise_Run_Angle  equ     $F593   ;
+Get_Rise_Idx    equ     $F5D9   ;
+Get_Run_Idx     equ     $F5DB   ;
+Get_Rise_Run    equ     $F5EF   ;
+Rise_Run_X      equ     $F5FF   ;
+Rise_Run_Y      equ     $F601   ;
+Rise_Run_Len    equ     $F603   ;
+Rot_VL_ab       equ     $F610   ;
+Rot_VL          equ     $F616   ;
+Rot_VL_Mode_a   equ     $F61F   ;
+Rot_VL_Mode     equ     $F62B   ;
+Rot_VL_dft      equ     $F637   ;
+Xform_Run_a     equ     $F65B   ;
+Xform_Run       equ     $F65D   ;
+Xform_Rise_a    equ     $F661   ;
+Xform_Rise      equ     $F663   ;
+Move_Mem_a_1    equ     $F67F   ;
+Move_Mem_a      equ     $F683   ;
+Init_Music_chk  equ     $F687   ;
+Init_Music      equ     $F68D   ;
+Init_Music_x    equ     $F692   ;
+Select_Game     equ     $F7A9   ;
+Clear_Score     equ     $F84F   ;
+Add_Score_a     equ     $F85E   ;
+Add_Score_d     equ     $F87C   ;
+Strip_Zeros     equ     $F8B7   ;
+Compare_Score   equ     $F8C7   ;
+New_High_Score  equ     $F8D8   ;
+Obj_Will_Hit_u  equ     $F8E5   ;
+Obj_Will_Hit    equ     $F8F3   ;
+Obj_Hit         equ     $F8FF   ;
+Explosion_Snd   equ     $F92E   ;
+Draw_Grid_VL    equ     $FF9F   ;
+                                ;
+music1  equ $FD0D               ;
+music2  equ $FD1D               ;
+music3  equ $FD81               ;
+music4  equ $FDD3               ;
+music5  equ $FE38               ;
+music6  equ $FE76               ;
+music7  equ $FEC6               ;
+music8  equ $FEF8               ;
+music9  equ $FF26               ;
+musica  equ $FF44               ;
+musicb  equ $FF62               ;
+musicc  equ $FF7A               ;
+musicd  equ $FF8F               ;
+
+;endif

--- a/code/veccart/led.c
+++ b/code/veccart/led.c
@@ -6,6 +6,9 @@
 #include <libopencm3/stm32/spi.h>
 #include "xprintf.h"
 #include "delay.h"
+#include "sys.h"
+
+extern system_options sys_opt;
 
 // APA102-2020 Driver - SPI2 Hardware
 // CS   - 33 - PB12  - SPI2_NSS  - NA v0.2 HW (currently V-HALT)
@@ -112,13 +115,21 @@ void rainbowCycle(uint8_t wait) {
 
 // Designed to step through a distributed rainbow equally distributed across the LEDs
 void rainbowStep(uint8_t step) {
-    static uint16_t i = 0;
+    static uint16_t n = 0;
     static uint8_t w = 0, j = 0;
     uint8_t *p;
     j += step;
-    for (i = 0; i < numLEDs; i++) {
-        w = ((i * 256 / numLEDs) + j) & 255;
-        p = &pixels[i * 3];
+    for (n = 0; n < numLEDs; n++) {
+        w = ((n * 256 / numLEDs) + j) & 255;
+        p = &pixels[n * 3];
+        if (sys_opt.hw_ver < 0x001e && sys_opt.rgb_type == RGB_TYPE_4) {
+            if (n <= 2 || n == 4 || n == 6 || n == 8) {
+                p[rOffset] = 0;
+                p[gOffset] = 0;
+                p[bOffset] = 0;
+                continue;
+            }
+        }
         if (w < 85) {
             p[rOffset] = w * 3;
             p[gOffset] = 255 - w;
@@ -383,19 +394,12 @@ void ledsUpdate() {
         for (i=0; i<4; i++) {
             spi_xfer(SPI2, 0x00);             // 4 byte start-frame marker
         }
-        if (brightness) {                     // Scale pixel brightness on output
-            do {                              // For each pixel...
-                spi_xfer(SPI2, 0xFF);         //  Pixel start
-                for (i=0; i<3; i++) {
-                    spi_xfer(SPI2, (*ptr++ * b16) >> 8); // Scale, write RGB
-                }
-            } while (--n);
-        } else {                              // Full brightness (no scaling)
-            do {                              // For each pixel...
-                spi_xfer(SPI2, 0xFF);         //  Pixel start
-                for(i=0; i<3; i++) spi_xfer(SPI2, *ptr++); // Write R,G,B
-            } while(--n);
-        }
+        do {                                  // For each pixel...
+            spi_xfer(SPI2, (0xE0 + brightness)); // Factor in brightness value
+            for (i=0; i<3; i++) {
+                spi_xfer(SPI2, *ptr++);       // Write R,G,B
+            }
+        } while(--n);
 
         // Four end-frame bytes are seemingly indistinguishable from a white
         // pixel, and empirical testing suggests it can be left out...but it's
@@ -410,21 +414,12 @@ void ledsUpdate() {
         for (i=0; i<4; i++) {
             leds_sw_spi_out(0);              // Start-frame marker
         }
-        if (brightness) {                    // Scale pixel brightness on output
-            do {                             // For each pixel...
-                leds_sw_spi_out(0xFF);       //  Pixel start
-                for (i=0; i<3; i++) {
-                    leds_sw_spi_out((*ptr++ * b16) >> 8); // Scale, write
-                }
-            } while(--n);
-        } else {                             // Full brightness (no scaling)
-            do {                             // For each pixel...
-                leds_sw_spi_out(0xFF);       //  Pixel start
-                for (i=0; i<3; i++) {
-                    leds_sw_spi_out(*ptr++); // R,G,B
-                }
-            } while(--n);
-        }
+        do {                                 // For each pixel...
+            leds_sw_spi_out(0xE0 + brightness); // Factor in brightness value
+            for (i=0; i<3; i++) {
+                leds_sw_spi_out(*ptr++);     // R,G,B
+            }
+        } while(--n);
         for (i=0; i<4; i++) {
             leds_sw_spi_out(0xFF);           // End-frame marker (see note above)
         }
@@ -439,6 +434,15 @@ void ledsClear() { // Write 0s (off) to full pixel buffer
 
 // Set pixel color, separate R,G,B values (0-255 ea.)
 void ledsSetPixelColorRGB(uint16_t n, uint8_t r, uint8_t g, uint8_t b) {
+    if (sys_opt.hw_ver < 0x1e && sys_opt.rgb_type == RGB_TYPE_4) {
+        if (n <= 2 || n == 4 || n == 6 || n == 8) {
+            uint8_t *p = &pixels[n * 3];
+            p[rOffset] = 0;
+            p[gOffset] = 0;
+            p[bOffset] = 0;
+            return;
+        }
+    }
     if (n < numLEDs) {
         uint8_t *p = &pixels[n * 3];
         p[rOffset] = r;
@@ -449,6 +453,15 @@ void ledsSetPixelColorRGB(uint16_t n, uint8_t r, uint8_t g, uint8_t b) {
 
 // Set pixel color, 'packed' RGB value (0x000000 - 0xFFFFFF)
 void ledsSetPixelColor(uint16_t n, uint32_t c) {
+    if (sys_opt.hw_ver < 0x1e && sys_opt.rgb_type == RGB_TYPE_4) {
+        if (n <= 2 || n == 4 || n == 6 || n == 8) {
+            uint8_t *p = &pixels[n * 3];
+            p[rOffset] = 0;
+            p[gOffset] = 0;
+            p[bOffset] = 0;
+            return;
+        }
+    }
     if (n < numLEDs) {
         uint8_t *p = &pixels[n * 3];
         p[rOffset] = (uint8_t)(c >> 16);
@@ -478,24 +491,18 @@ uint16_t ledsNumPixels() { // Ret. strip length
 }
 
 // Set global strip brightness.  This does not have an immediate effect;
-// must be followed by a call to show().  Not a fan of this...for various
-// reasons I think it's better handled in one's sketch, but it's here for
-// parity with the NeoPixel library.  Good news is that brightness setting
-// in this library is 'non destructive' -- it's applied as color data is
-// being issued to the strip, not during setPixel(), and also means that
-// getPixelColor() returns the exact value originally stored.
+// must be followed by a call to show(). Good news is that brightness setting
+// in this library is 'non destructive' -- it's applied as global data
+// being issued to the upper byte of each pixel, not during setPixel(),
+// and also means that getPixelColor() returns the exact value originally stored.
 void ledsSetBrightness(uint8_t b) {
-    // Stored brightness value is different than what's passed.  This
-    // optimizes the actual scaling math later, allowing a fast 8x8-bit
-    // multiply and taking the MSB.  'brightness' is a uint8_t, adding 1
-    // here may (intentionally) roll over...so 0 = max brightness (color
-    // values are interpreted literally; no scaling), 1 = min brightness
-    // (off), 255 = just below max brightness.
-    brightness = b + 1;
+    // global brightness value is 5 bits in the MSB of each 32-bit pixel data
+    // 111xxxxx RRRRRRRR GGGGGGGG BBBBBBBB, where xxxxx is 0 - 31 brightness
+    brightness = b >> 3;
 }
 
 uint8_t ledsGetBrightness() {
-    return brightness - 1; // Reverse above operation
+    return brightness << 3; // Reverse above operation
 }
 
 // Return pointer to the library's pixel data buffer.  Use carefully,

--- a/code/veccart/menu.h
+++ b/code/veccart/menu.h
@@ -16,7 +16,7 @@ typedef struct {
 } dir_listing;
 
 int removeExtension(char* filename, char* extension);
-void sortDirectory(char *fdir, dir_listing *listing); 
+void sortDirectory(char *fdir, dir_listing *listing);
 void loadListing(char *fdir, dir_listing *listing, const int fnptrs, const int strptrs, char *romData); 
 
 #endif

--- a/code/veccart/sys.h
+++ b/code/veccart/sys.h
@@ -1,0 +1,18 @@
+#ifndef SYSTEM_H
+#define SYSTEM_H
+
+enum RGB_TYPE {
+    RGB_TYPE_NONE = 0,
+    RGB_TYPE_10 = 1,
+    RGB_TYPE_4 = 2,
+};
+
+typedef struct {
+    uint16_t size; // size of this struct
+    uint16_t ver; // system_options version
+    uint16_t hw_ver; // 0x0014 = 0.21
+    uint8_t  rgb_type; // RGB_LED_TYPE
+    uint8_t  reserved[128-7];
+} system_options;
+
+#endif


### PR DESCRIPTION
### Problem

See issue #46 
 
### Solution

- Brightness control was changed to not scale the pixel information, but instead to utilize the global 5-bit brightness control of the APA102-2020 super leds :D
- Brightness RPC function ID 8 was added to allow control of brightness from Vectrex games
- LED Test v2.0 was added to show the new brightness control in action.  See the readme.md in the led-test2/ folder
- System Options structure was added for hw_ver, and rgb_type.  Currently these are used to allow the user to build the STM32 firmware for different LED options, but will also be used for v0.30 VEXTREME hardware which will only have 4 LEDs.

### Steps to Test

- Build the veccart for the different 3 different RGB_TYPE's and led-test2 app, then run the led-test2 app to observe the effects.  Yes I did this :D 

### References

fixes #46 
