### PR TITLE
Ignore all file extensions that are not '.bin' or '.vec'

### DIFF
--- a/code/veccart/delay.c
+++ b/code/veccart/delay.c
@@ -4,6 +4,8 @@
 
 volatile uint32_t sysTimerMs;
 
+extern void sys_tick_handler(void);
+
 // Called when systick fires
 void sys_tick_handler(void) {
     sysTimerMs++;

--- a/code/veccart/delay.h
+++ b/code/veccart/delay.h
@@ -1,7 +1,6 @@
 #ifndef DELAY_H
 #define DELAY_H
 
-void sys_tick_handler(void);
 void delay(uint32_t wait);
 uint32_t millis(void);
 

--- a/code/veccart/flash.c
+++ b/code/veccart/flash.c
@@ -60,7 +60,8 @@ static void flashCs(int i) {
 	if (i) gpio_set(GPIOA, GPIO15); else gpio_clear(GPIOA, GPIO15);
 }
 
-static void flashEraseChip() {
+__attribute__((unused))
+static void flashEraseChip(void) {
 	int status;
 	xprintf("Erasing chip...\n");
 	//Send write enable
@@ -206,7 +207,7 @@ int flashWriteBlk(uint32_t lba, const uint8_t *copy_from) {
 
 //	xprintf("Write lba %d (addr %x blkaddr %x)\n", lba, addr, blkaddr);
 
-	if (blkaddr!=flashBlkAddr) {
+	if (blkaddr != (uint32_t)flashBlkAddr) {
 		//Write back data in block cache, if any
 		flashDoWriteback();
 		gpio_set(GPIOB, GPIO0); //turn on LED

--- a/code/veccart/led.c
+++ b/code/veccart/led.c
@@ -200,14 +200,14 @@ uint32_t colorWheel(uint8_t WheelPos) {
 //         Effective range is 2 - 8, 4 is default for 16 pixels.  Play with this.
 // Color - 32-bit packed RGB color value.  All pixels will be this color.
 // knightRider(cycles, speed, width, color);
-void knightRider(uint16_t cycles, uint16_t speed, uint8_t width, uint16_t first, uint16_t last, uint32_t color) {
+void __attribute__((optimize("O0"))) knightRider(uint16_t cycles, uint16_t speed, uint8_t width, uint16_t first, uint16_t last, uint32_t color) {
   uint32_t old_val[last+1]; // up to 256 lights!
   // Larson time baby!
   for (int i = 0; i < cycles; i++) {
     for (int count = first+1; count<last+1; count++) {
       ledsSetPixelColor(count, color);
       old_val[count] = color;
-      for(int x = count; x>0; x--) {
+      for (int x = count; x>0; x--) {
         old_val[x-1] = dimColor(old_val[x-1], width);
         ledsSetPixelColor(x-1, old_val[x-1]);
       }
@@ -239,7 +239,7 @@ void theaterChaseRainbow(int wait) {
         // revolution of the color wheel (range 65536) along the length
         // of the strip (ledsNumPixels() steps):
         int      hue   = firstPixelHue + c * 65536L / ledsNumPixels();
-        uint32_t color = ledsGamma32(ledsColorHSV(hue)); // hue -> RGB
+        uint32_t color = ledsGamma32(ledsColorHSV2(hue, 255, 255)); // hue -> RGB
         ledsSetPixelColor(c, color); // Set pixel 'c' to value 'color'
       }
       ledsUpdate();                // Update strip with new contents
@@ -385,7 +385,6 @@ void ledsUpdate() {
 
     uint8_t *ptr = pixels, i;            // -> LED data
     uint16_t n   = numLEDs;              // Counter
-    uint16_t b16 = (uint16_t)brightness; // Type-convert for fixed-point math
 
     //__disable_irq(); // If 100% focus on SPI clocking required
 
@@ -624,7 +623,7 @@ uint32_t ledsGamma32(uint32_t x) {
     // of an RGB value, but this seems exceedingly rare and if it's
     // encountered in reality they can mask values going in or coming out.
     for (uint8_t i=0; i<4; i++) {
-        y[i] = ledsGamma8(y[i]);
+        y[i] = _LedsGammaTable[y[i]]; // 0-255 in, 0-255 out
     }
     return x; // Packed 32-bit return
 }

--- a/code/veccart/led.h
+++ b/code/veccart/led.h
@@ -34,7 +34,7 @@
 #define RGB_BGR (2 | (1 << 2) | (0 << 4))
 
 // Addressable LED Preset Colors
-static uint32_t colors[] = {
+static const uint32_t colors[10] = {
     0,        // off
     0xFF0000, // red
     0xFF9900, // orange
@@ -77,6 +77,7 @@ static const uint8_t _LedsGammaTable[256] = {
 uint32_t Wheel(uint8_t WheelPos);
 void rainbow(uint8_t wait);
 void rainbowCycle(uint8_t wait);
+void rainbowStep(uint8_t step);
 void colorWipe(bool dir, uint32_t c, uint8_t wait);
 uint32_t dimColor(uint32_t color, uint8_t width);
 uint32_t colorWheel(uint8_t WheelPos);
@@ -107,14 +108,6 @@ uint8_t *ledsGetPixels(void);                        // Return pixel data pointe
  * colors. Makes color transitions appear more perceptially correct.
  */
 uint32_t ledsColorHSV2(uint16_t hue, uint8_t sat, uint8_t val);
-static uint32_t ledsColorHSV(uint32_t x) {
-    return ledsColorHSV2(x, 255, 255); // sat = 255, val = 255
-}
-
-static uint8_t ledsGamma8(uint8_t x) {
-    return _LedsGammaTable[x]; // 0-255 in, 0-255 out
-}
-
 uint32_t ledsGamma32(uint32_t x);
 
 #endif // _ADAFRUIT_DOT_STAR_H_

--- a/code/veccart/main.c
+++ b/code/veccart/main.c
@@ -382,17 +382,17 @@ int main(void) {
 		rainbowCycle(10);
 
 		ledsClear();
-		knightRider(6, 64, 4, 2, 8, 0xFF7700); // Cycles, Speed, Width, First, Last, RGB Color (original orange-red)
-		knightRider(3, 32, 4, 2, 8, 0xFF00FF); // Cycles, Speed, Width, First, Last, RGB Color (purple)
-		knightRider(3, 32, 4, 2, 8, 0x0000FF); // Cycles, Speed, Width, First, Last, RGB Color (blue)
-		knightRider(3, 32, 5, 2, 8, 0x00FF00); // Cycles, Speed, Width, First, Last, RGB Color (green)
-		knightRider(3, 32, 5, 2, 8, 0xFFFF00); // Cycles, Speed, Width, First, Last, RGB Color (yellow)
-		knightRider(3, 32, 7, 2, 8, 0x00FFFF); // Cycles, Speed, Width, First, Last, RGB Color (cyan)
-		knightRider(3, 32, 7, 2, 8, 0xFFFFFF); // Cycles, Speed, Width, First, Last, RGB Color (white)
+		knightRider(6, 64, 4, 3, 9, 0xFF7700); // Cycles, Speed, Width, First, Last, RGB Color (original orange-red)
+		knightRider(3, 32, 4, 3, 9, 0xFF00FF); // Cycles, Speed, Width, First, Last, RGB Color (purple)
+		knightRider(3, 32, 4, 3, 9, 0x0000FF); // Cycles, Speed, Width, First, Last, RGB Color (blue)
+		knightRider(3, 32, 5, 3, 9, 0x00FF00); // Cycles, Speed, Width, First, Last, RGB Color (green)
+		knightRider(3, 32, 5, 3, 9, 0xFFFF00); // Cycles, Speed, Width, First, Last, RGB Color (yellow)
+		knightRider(3, 32, 7, 3, 9, 0x00FFFF); // Cycles, Speed, Width, First, Last, RGB Color (cyan)
+		knightRider(3, 32, 7, 3, 9, 0xFFFFFF); // Cycles, Speed, Width, First, Last, RGB Color (white)
 
 		// Iterate through a whole rainbow of colors
 		for(uint8_t j=0; j<252; j+=7) {
-			knightRider(1, 16, 2, 0, 8, colorWheel(j)); // Cycles, Speed, Width, RGB Color
+			knightRider(1, 16, 2, 0, 10, colorWheel(j)); // Cycles, Speed, Width, RGB Color
 		}
 
 		ledsClear();

--- a/code/veccart/main.h
+++ b/code/veccart/main.h
@@ -9,8 +9,8 @@ void doChangeDir(char* dirname);
 void doChangeRom(char* basedir, int i);
 void doHandleEvent(int data);
 void doDbgHook(int adr, int data);
-void updateAll();
-void updateOne();
-void updateMulti();
+void updateAll(void);
+void updateOne(void);
+void updateMulti(void);
 
 #endif

--- a/code/veccart/menu.c
+++ b/code/veccart/menu.c
@@ -1,4 +1,6 @@
+#define _GNU_SOURCE // required for strcasestr
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "menu.h"
@@ -30,15 +32,16 @@ void loadListing(char *fdir, dir_listing *listing, const int fnptrs, const int s
 
 		is_dir=f_entry->is_dir;
 
-		//xprintf("Found file %s (%d), file %d\n", name, is_dir, idx);
+		// xprintf("Found file %s (%d), file %d\n", name, is_dir, idx);
 		romData[ptrpos++]=strpos>>8;
 		romData[ptrpos++]=strpos&0xff;
 
 		// remove extensions
-		removeExtension(name, ".bin");
-		removeExtension(name, ".BIN");
-		removeExtension(name, ".vec");
-		removeExtension(name, ".VEC");
+		const char* extList[2] = { ".bin", ".vec" };
+		int is_game = checkExtension(name, extList, 2, true); // check and modify
+		if (!is_game && !is_dir) {
+			continue; // If not a game, don't list it in the menu
+		}
 
 		i = is_dir ? (MENU_TEXT_LEN-2) : MENU_TEXT_LEN;
 		if (is_dir) romData[strpos++]='<';
@@ -64,11 +67,15 @@ void loadListing(char *fdir, dir_listing *listing, const int fnptrs, const int s
 	xprintf("Done.\n");
 }
 
-int removeExtension(char* filename, char* extension) {
-	char* ptr = strstr(filename,extension);
-	if (ptr) {
-		*ptr = 0;
-		return 1;
+int checkExtension(char* filename, const char** extlist, int size, bool modify) {
+	for (int i = 0; i < size; i++ ) {
+		char* ptr = strcasestr(filename, extlist[i]);
+		if (ptr) {
+			if (modify) {
+				*ptr = 0;
+			}
+			return 1;
+		}
 	}
 	return 0;
 }
@@ -117,10 +124,20 @@ void sortDirectory(char *fdir, dir_listing *listing) {
 		}
 
 		is_dir = (fi.fattrib & AM_DIR) ? 1 : 0;
+
+
 		if (fi.lfname[0]=='.') continue; // ignore MacOS dotfiles
 		name=fi.lfname;
 		if (name==NULL || name[0]==0) name=fi.fname; //use short name if no long name available
 
+		// check extensions and ignore all non case insensitive .bin/.vec files
+		const char* extList[2] = { ".bin", ".vec" };
+		int is_game = checkExtension(name, extList, 2, false); // check only
+		if (!is_game && !is_dir) {
+			continue; // If not a game or directory, don't list it in the menu
+		}
+
+		// add file/dir to listing
 		f_entry->is_dir = is_dir;
 		strcpy(f_entry->fname, name);
 		idx++;

--- a/code/veccart/menu.h
+++ b/code/veccart/menu.h
@@ -15,7 +15,7 @@ typedef struct {
 	file_entry f_entry[80];
 } dir_listing;
 
-int removeExtension(char* filename, char* extension);
+int checkExtension(char* filename, const char** extlist, int size, bool modify);
 void sortDirectory(char *fdir, dir_listing *listing);
 void loadListing(char *fdir, dir_listing *listing, const int fnptrs, const int strptrs, char *romData); 
 


### PR DESCRIPTION
### Problem

See issue #27

### Solution

- Reworked the removeExtension() function to be more of a test for games vs. non-games
- Made removeExtension() function more extensible with strcasestr() which ignores case
- Changed removeExtension() to checkExtension() which can simply check or modify extensions.
- Also cleaned up a bunch of compiler warnings

### Steps to Test

- Try adding various file extensions .bin / .vec / .vEC / .BiN / .txt / .md / .jpg / etc..
- Menu should build normally and games should play fine

### References

Closes #27 