### PR TITLE
Truncate filenames displayed to 16 characters and fix long filename bug

### DIFF
--- a/code/veccart/main.c
+++ b/code/veccart/main.c
@@ -423,7 +423,7 @@ void doRamDisk() {
 
 // Handle an RPC event
 void doHandleEvent(int data) {
-	xprintf("[E:%d,A:%02X]\n", data, (int)parmRam[254]);
+	// xprintf("[E:%d,A:%02X]\n", data, (int)parmRam[254]);
 	switch (data) {
 		default:
 		case 0: break;

--- a/code/veccart/menu.c
+++ b/code/veccart/menu.c
@@ -11,7 +11,7 @@
 //Get a listing of the roms in the 'roms/' directory and
 //poke them into the menu cartridge space
 void loadListing(char *fdir, dir_listing *listing, const int fnptrs, const int strptrs, char *romData) {
-	char buff[30];
+	char buff[sizeof(listing->f_entry->fname)];
 	char *name;
 
 	int ptrpos = fnptrs;  // fixed location in multicart.bin for 512 filename pointers (from &ptrpos ~ &strpos)

--- a/code/veccart/menu.h
+++ b/code/veccart/menu.h
@@ -3,7 +3,7 @@
 
 #include "fatfs/ff.h"
 
-#define MENU_TEXT_LEN 20
+#define MENU_TEXT_LEN 16
 
 typedef struct {
 	int is_dir;


### PR DESCRIPTION
### Problem

See Issue #58

### Solution

- Temp buffer was not large enough to hold large files (up to 255).
- Too many characters displayed, going off the edge of the screen, reduce from 20 to 16.

### Steps to Test

See Issue #58