### PR TITLE
Implements #55 High Score (by @TylerBrymer PR #56)

### DIFF
--- a/code/veccart/Makefile
+++ b/code/veccart/Makefile
@@ -45,7 +45,8 @@ ASFLAGS += -DHW_VER=$(HW_VER_VAL)
 
 BINARY=veccart
 OBJS=main.o menu.o romemu.o msc.o xprintf.o usb_msc.o ff_diskio.o \
-		fatfs/ff.o fatfs/option/unicode.o flash.o led.o delay.o
+		fatfs/ff.o fatfs/option/unicode.o flash.o led.o delay.o \
+		highscore.o
 
 LIBNAME = opencm3_stm32f4
 ARCH_FLAGS = -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb -mcpu=cortex-m4 -DSTM32F4

--- a/code/veccart/highscore.c
+++ b/code/veccart/highscore.c
@@ -1,0 +1,397 @@
+/*
+ *  Copyright (C) 2020
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+// Includes
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "flash.h"
+#include "xprintf.h"
+#include "fatfs/ff.h"
+
+#include "highscore.h"
+
+// Externs
+
+// Globals
+
+static FIL fileHighScore;   // Highscore file pointer
+static FRESULT fResult;     // Highscore file return results
+
+// Local variables
+static GameFileRecord activeGameData;
+
+// Global Varablies
+GameFileRecord * pActiveGameData = &activeGameData;
+
+
+// Local functions
+static int highScoreGetFileNameSize(const unsigned char * pString);
+
+/**
+ * Open High score file locted on flash file system.  If it doesn't exist
+ * create the file.
+ */
+FRESULT highScoreOpenFile(void)
+{
+    // Create/Open highscore file
+    fResult = f_open(&fileHighScore, "/hs.bin", FA_OPEN_ALWAYS | FA_READ | FA_WRITE);
+
+    return fResult;
+}
+
+/**
+ * Search for the game by name in the highscore file, and if it exists, 
+ * read the game record associated with the name and store it in the
+ * location pointed to by the second parameter (pGameRecord).
+ *
+ * @param[in] - pGame - Points to a 0x80 terminated game name
+ * @param[out] - pGameRecord - Location to store game data record, or NULL
+ *                             to store in out active game location
+ *
+ * @return - HIGH_SCORE_SUCCESS or error code for failure
+ *           pGameRecord = Game record is stored here on success
+ *           fileHighScore->fptr = EOF or start of record for the game
+ */
+HighScoreRetVal highScoreGet(const unsigned char * pGameName, GameFileRecord * pGameRecord)
+{
+    int retVal = HIGH_SCORE_GAME_NOT_FOUND;
+    unsigned int bytesRead = 0;
+    bool exit = false;
+
+    /**
+     * Check for invalid parameter for game name
+     */
+    if (pGameName == NULL)
+    {
+	return (HIGH_SCORE_GAME_NAME_INVALID_PTR);
+    }
+    
+    /**
+     * Check to make sure file was opened successfully
+     */
+    if (fResult != FR_OK)
+    {
+        return (HIGH_SCORE_FILE_OPEN_FAIL);
+    }
+
+    /**
+     * Calculate size of the 0x80 terminated string passed into function
+     */
+    int gameNameSize = highScoreGetFileNameSize(pGameName);
+
+    /**
+     * Return failure if name of game is 0
+     */
+    if (gameNameSize == 0)
+    {
+        return (HIGH_SCORE_GAME_NAME_SIZE_ZERO);
+    }
+
+    /**
+     * Exit if the game name passed to this function is larger than we allow
+     */
+    if (gameNameSize > (MAX_GAME_NAME_SIZE))
+    {
+        return (HIGH_SCORE_GAME_NAME_TOO_LONG);
+    }
+
+    /**
+     * Set game record pointer to the active local game data pointer
+     * if user passed in NULL
+     */
+    if (pGameRecord == NULL)
+    {
+        pGameRecord = pActiveGameData;
+    }
+
+    /**
+     * Move file pointer to beginning of the file
+     */
+    f_lseek(&fileHighScore, 0);
+    
+    /**
+     * Search for game in file
+     */
+    do
+    {
+        /**
+         * Read a high score record from file
+         */
+        fResult = f_read(&fileHighScore, pGameRecord, sizeof(GameFileRecord), &bytesRead);
+
+        /**
+         * Exit if EOF or another read issue
+         */
+        if ((fResult != FR_OK) || (bytesRead == 0))
+        {
+            exit = true;    
+        }
+
+        /**
+         * Compare passed in game name to game name read from file
+         */
+        if ( (0 == strncmp((char *)pGameName, (char *)pGameRecord->name, gameNameSize))  &&
+	     (exit == false) )
+        {
+	    /**
+	     * Move file pointer back to the beginning of the record for 
+	     * the game, to prepare writing of the new high score if it
+	     * is beat.
+	     */
+	    f_lseek(&fileHighScore, f_tell(&fileHighScore) - sizeof(GameFileRecord));
+
+     	    /**
+	     * Found matching game
+	     */
+	    exit = true;
+	    retVal = HIGH_SCORE_SUCCESS;
+	}
+    } while (exit == false);
+
+    return retVal;
+}
+
+/**
+ * Initialize a game record to the defaults and add the name pointed to by pGameName
+ * @param[in] - pGameName - Pointer to the game name in the ROM - 0x80 terminated
+ * @param[in] - pGameRecord - Pointer to a game record, or NULL (If NULL, use active)
+ *
+ * @return - HIGH_SCORE_SUCCESS, or error code
+ */
+HighScoreRetVal highScoreSetGameRecordToDefaults(const unsigned char * pGameName, GameFileRecord * pGameRecord)
+{
+    int retVal = HIGH_SCORE_SUCCESS;
+    char defaultScore[] = {' ', ' ', ' ', ' ', ' ', '0', '\0'};
+
+    /**
+     * Check for invalid parameter for game name
+     */
+    if (pGameName == NULL)
+    {
+        return (HIGH_SCORE_GAME_NAME_INVALID_PTR);
+    }
+
+    /**
+     * Set game record pointer to the active local game data pointer
+     * if user passed in NULL
+     */
+    if (pGameRecord == NULL)
+    {
+        pGameRecord = pActiveGameData;
+    }
+
+    /**
+     * Calculate size of the 0x80 terminated string passed into function
+     */
+    int gameNameSize = highScoreGetFileNameSize(pGameName);
+
+    /**
+     * Exit if the game name passed to this function is larger than we allow
+     */
+    if (gameNameSize > (MAX_GAME_NAME_SIZE - 1))
+    {
+        return (HIGH_SCORE_GAME_NAME_TOO_LONG);
+    }
+
+    /**
+     * Return failure if name of game is 0
+     */
+    if (gameNameSize == 0)
+    {
+        return (HIGH_SCORE_GAME_NAME_SIZE_ZERO);
+    }
+
+    /**
+     * Initialize the high score to default of zero
+     */
+    strncpy((char *)pGameRecord->maxScore, defaultScore, MAX_GAME_SCORE_SIZE);
+
+    /**
+     * Move name into active game record name field, followed by a NULL byte
+     */
+    int count = 0;
+    for (count = 0; (count < MAX_GAME_NAME_SIZE) && (count < gameNameSize); count++)
+    {
+        pGameRecord->name[count] = pGameName[count];
+    }
+
+    /**
+     * NULL terminate the string for storing in our game records
+     */
+
+    for (; count < MAX_GAME_NAME_SIZE; count++)
+    {
+        pGameRecord->name[count] = '\0';
+    }
+
+    return retVal;
+}
+
+/**
+ * Return the size of the games name string, excluding the trailing 0x80
+ *
+ * param[in] - pString - 0x80 terminated game name string as found in 
+ * cartridge.
+ *
+ * TODO - Update to grab the second portion of the string.  Look up to 0x80 0x00
+ * then back up to get both strings
+ */
+static int highScoreGetFileNameSize(const unsigned char * pString)
+{
+    int count = 0;
+
+    for (count = 0; count < MAX_GAME_NAME_SIZE; count++)
+    {
+	if (pString[count] == 0x80)
+	{
+	    break;
+	}
+    }
+    return count;
+}
+
+/**
+ * If the score pointed to by pScore is larger than the current maximum
+ * score stored in the active game data record, then update it and
+ * write it to the high score file.
+ *
+ * @param[in] - Pointer to 0x80 terminated high score
+ */
+void highScoreSave(unsigned char * pScore)
+{
+    int i = 0;
+
+    /**
+     * Compare this new high score to see if it is greater
+     * than the overall high score for this game stored in 
+     * the highScore file.
+     */
+    HighScoreCompare retVal = highScoreCompare(pActiveGameData->maxScore, pScore);
+
+    /**
+     * If the new score in pScore is greater than the current max score we read from
+     * the file, then we need to update the active game data record with the new
+     * high score so it will be saved to the file.
+     */
+    if (retVal == HIGH_SCORE1_LESS_SCORE2)
+    {
+        /**
+         * Move new high score into global current game record
+         */
+        for (i = 0; i < (MAX_GAME_SCORE_SIZE - 1); i++)
+        {
+           pActiveGameData->maxScore[i]  = pScore[i];
+        }
+
+        /**
+         * Add '\0' to end of string
+         */
+        pActiveGameData->maxScore[i]  = '\0';
+
+	/**
+	 * Write the updated game record to the file
+	 * Note: The write pointer should be correct, either the end
+	 * of the file for a new game, or the beginning of the game
+	 * record where the update needs to happen.
+	 */
+	(void)highScoreStore(pActiveGameData);
+    }
+}
+
+/**
+ * Store the game record into the fileHighScore at the current write
+ * pointer.
+ *
+ * @param[in] - Pointer to the game record to store
+ *
+ * @return - HIGH_SCORE_SUCCESS or HIGH_SCORE_WRITE_FAIL
+ */
+HighScoreRetVal highScoreStore(GameFileRecord * pGameRecord)
+{
+    unsigned int bytesWrote = 0;
+
+    /**
+     * Set game record pointer to the active local game data pointer
+     * if user passed in NULL
+     */
+    if (pGameRecord == NULL)
+    {
+        pGameRecord = pActiveGameData;
+    }
+
+    if (pGameRecord->name[0] == 0x00)
+    {
+        return HIGH_SCORE_INVALID_NAME;
+    }
+
+    /**
+     * Store a high score record to the file
+     */
+    fResult = f_write(&fileHighScore, pGameRecord, sizeof(GameFileRecord), &bytesWrote);
+
+    if ( (bytesWrote < sizeof(GameFileRecord)) || (fResult != FR_OK) )
+    {
+        return HIGH_SCORE_WRITE_FAIL;
+    }
+
+    /**
+     * Flush the file data
+     */
+    f_sync(&fileHighScore);
+
+    /**
+     * Flush record to flash device
+     */
+    flashDoWriteback();
+
+    return HIGH_SCORE_SUCCESS;
+}
+
+/**
+ * Compare two scores in string BCD format with preceding
+ * spaces as kept by the vectrex. 
+ * Note: A maximum of six bytes are compared. 
+ *
+ * @param[in] - pScore1 - Pointer to first score
+ * @param[in] - pScore2 - Pointer to second score
+ *
+ * @return - HIGH_SCORES_EQUAL, HIGH_SCORE1_LESS_SCORE2,
+ * HIGH_SCORE2_LESS_SCORE1
+ *
+ */
+HighScoreCompare highScoreCompare(const unsigned char * pScore1, const unsigned char * pScore2)
+{
+    HighScoreCompare retVal = HIGH_SCORES_EQUAL;
+
+    int i = 0;
+    for (i = 0; i < (MAX_GAME_SCORE_SIZE - 1); i++)
+    {
+        if (pScore1[i] < pScore2[i])
+	{
+            retVal = HIGH_SCORE1_LESS_SCORE2;
+	    break;
+	}
+	else if (pScore2[i] < pScore1[i])
+	{
+            retVal = HIGH_SCORE2_LESS_SCORE1;
+	    break;
+	}
+    }
+    return (retVal);
+}

--- a/code/veccart/highscore.c
+++ b/code/veccart/highscore.c
@@ -56,7 +56,7 @@ FRESULT highScoreOpenFile(void)
 }
 
 /**
- * Search for the game by name in the highscore file, and if it exists, 
+ * Search for the game by name in the highscore file, and if it exists,
  * read the game record associated with the name and store it in the
  * location pointed to by the second parameter (pGameRecord).
  *
@@ -79,9 +79,9 @@ HighScoreRetVal highScoreGet(const unsigned char * pGameName, GameFileRecord * p
      */
     if (pGameName == NULL)
     {
-	return (HIGH_SCORE_GAME_NAME_INVALID_PTR);
+        return (HIGH_SCORE_GAME_NAME_INVALID_PTR);
     }
-    
+
     /**
      * Check to make sure file was opened successfully
      */
@@ -124,7 +124,7 @@ HighScoreRetVal highScoreGet(const unsigned char * pGameName, GameFileRecord * p
      * Move file pointer to beginning of the file
      */
     f_lseek(&fileHighScore, 0);
-    
+
     /**
      * Search for game in file
      */
@@ -140,28 +140,27 @@ HighScoreRetVal highScoreGet(const unsigned char * pGameName, GameFileRecord * p
          */
         if ((fResult != FR_OK) || (bytesRead == 0))
         {
-            exit = true;    
+            exit = true;
         }
 
         /**
          * Compare passed in game name to game name read from file
          */
         if ( (0 == strncmp((char *)pGameName, (char *)pGameRecord->name, gameNameSize))  &&
-	     (exit == false) )
+         (exit == false) )
         {
-	    /**
-	     * Move file pointer back to the beginning of the record for 
-	     * the game, to prepare writing of the new high score if it
-	     * is beat.
-	     */
-	    f_lseek(&fileHighScore, f_tell(&fileHighScore) - sizeof(GameFileRecord));
+            /**
+             * Move file pointer back to the beginning of the record for the
+             * game, to prepare writing of the new high score if it is beat.
+             */
+            f_lseek(&fileHighScore, f_tell(&fileHighScore) - sizeof(GameFileRecord));
 
-     	    /**
-	     * Found matching game
-	     */
-	    exit = true;
-	    retVal = HIGH_SCORE_SUCCESS;
-	}
+                /**
+             * Found matching game
+             */
+            exit = true;
+            retVal = HIGH_SCORE_SUCCESS;
+        }
     } while (exit == false);
 
     return retVal;
@@ -246,7 +245,7 @@ HighScoreRetVal highScoreSetGameRecordToDefaults(const unsigned char * pGameName
 /**
  * Return the size of the games name string, excluding the trailing 0x80
  *
- * param[in] - pString - 0x80 terminated game name string as found in 
+ * param[in] - pString - 0x80 terminated game name string as found in
  * cartridge.
  *
  * TODO - Update to grab the second portion of the string.  Look up to 0x80 0x00
@@ -258,10 +257,10 @@ static int highScoreGetFileNameSize(const unsigned char * pString)
 
     for (count = 0; count < MAX_GAME_NAME_SIZE; count++)
     {
-	if (pString[count] == 0x80)
-	{
-	    break;
-	}
+        if (pString[count] == 0x80)
+        {
+            break;
+        }
     }
     return count;
 }
@@ -279,7 +278,7 @@ void highScoreSave(unsigned char * pScore)
 
     /**
      * Compare this new high score to see if it is greater
-     * than the overall high score for this game stored in 
+     * than the overall high score for this game stored in
      * the highScore file.
      */
     HighScoreCompare retVal = highScoreCompare(pActiveGameData->maxScore, pScore);
@@ -304,13 +303,13 @@ void highScoreSave(unsigned char * pScore)
          */
         pActiveGameData->maxScore[i]  = '\0';
 
-	/**
-	 * Write the updated game record to the file
-	 * Note: The write pointer should be correct, either the end
-	 * of the file for a new game, or the beginning of the game
-	 * record where the update needs to happen.
-	 */
-	(void)highScoreStore(pActiveGameData);
+        /**
+         * Write the updated game record to the file
+         * Note: The write pointer should be correct, either the end
+         * of the file for a new game, or the beginning of the game
+         * record where the update needs to happen.
+         */
+        (void)highScoreStore(pActiveGameData);
     }
 }
 
@@ -365,8 +364,8 @@ HighScoreRetVal highScoreStore(GameFileRecord * pGameRecord)
 
 /**
  * Compare two scores in string BCD format with preceding
- * spaces as kept by the vectrex. 
- * Note: A maximum of six bytes are compared. 
+ * spaces as kept by the vectrex.
+ * Note: A maximum of six bytes are compared.
  *
  * @param[in] - pScore1 - Pointer to first score
  * @param[in] - pScore2 - Pointer to second score
@@ -383,15 +382,15 @@ HighScoreCompare highScoreCompare(const unsigned char * pScore1, const unsigned 
     for (i = 0; i < (MAX_GAME_SCORE_SIZE - 1); i++)
     {
         if (pScore1[i] < pScore2[i])
-	{
+        {
             retVal = HIGH_SCORE1_LESS_SCORE2;
-	    break;
-	}
-	else if (pScore2[i] < pScore1[i])
-	{
+            break;
+        }
+        else if (pScore2[i] < pScore1[i])
+        {
             retVal = HIGH_SCORE2_LESS_SCORE1;
-	    break;
-	}
+            break;
+        }
     }
     return (retVal);
 }

--- a/code/veccart/highscore.c
+++ b/code/veccart/highscore.c
@@ -106,7 +106,7 @@ HighScoreRetVal highScoreGet(const unsigned char * pGameName, GameFileRecord * p
     /**
      * Exit if the game name passed to this function is larger than we allow
      */
-    if (gameNameSize > (MAX_GAME_NAME_SIZE))
+    if (gameNameSize > (MAX_GAME_NAME_SIZE - 1))
     {
         return (HIGH_SCORE_GAME_NAME_TOO_LONG);
     }
@@ -254,15 +254,15 @@ HighScoreRetVal highScoreSetGameRecordToDefaults(const unsigned char * pGameName
 static int highScoreGetFileNameSize(const unsigned char * pString)
 {
     int count = 0;
-
-    for (count = 0; count < MAX_GAME_NAME_SIZE; count++)
+    // Iterate to (MAX_GAME_NAME_SIZE - 1) since Vectrex doesn't null terminate
+    for (count = 0; count < (MAX_GAME_NAME_SIZE - 1); count++)
     {
         if (pString[count] == 0x80)
         {
-            break;
+            return count;
         }
     }
-    return count;
+    return MAX_GAME_NAME_SIZE;
 }
 
 /**

--- a/code/veccart/highscore.h
+++ b/code/veccart/highscore.h
@@ -1,0 +1,57 @@
+#ifndef HIGHSCORE_H
+#define HIGHSCORE_H
+
+// Includes
+#include "fatfs/ff.h"
+
+// Constants
+#define MAX_GAME_NAME_SIZE	(40 + 1) // Max of 40 ASCII characters + NULL
+#define MAX_GAME_SCORE_SIZE     (6 + 1)  // Max of 6 ASCII characters + NULL
+
+typedef enum
+{
+    HIGH_SCORE_SUCCESS = 0,
+    HIGH_SCORE_FILE_OPEN_FAIL = 1,
+    HIGH_SCORE_GAME_NOT_FOUND = 2,
+    HIGH_SCORE_GAME_NAME_TOO_LONG = 3,
+    UNUSED1 = 4,
+    HIGH_SCORE_GAME_NAME_SIZE_ZERO = 5,
+    HIGH_SCORE_GAME_NAME_INVALID_PTR = 6,
+    UNUSED2 = 5,
+    HIGH_SCORE_WRITE_FAIL = 7,
+    HIGH_SCORE_INVALID_NAME = 8,
+    HIGH_SCORE_FAIL    = 0xFFFFFFFF // 32-bit -1
+} HighScoreRetVal;
+
+typedef enum
+{
+    HIGH_SCORES_EQUAL = 6,
+    HIGH_SCORE1_LESS_SCORE2 = 7,
+    HIGH_SCORE2_LESS_SCORE1 = 8
+} HighScoreCompare;
+
+// Sructures
+
+// A fame file record is exactly 48 bytes
+typedef struct
+{
+    unsigned char name[MAX_GAME_NAME_SIZE];  // NULL terminated name string
+    unsigned char maxScore[MAX_GAME_SCORE_SIZE]; // NULL terminated high score string
+} __attribute__((packed))GameFileRecord;
+
+
+// The format of the highscore file will be:
+// GameName, HighScore
+// GameName will be the same format used in a ROM game cartridge: ASCII bytes followed by NULL
+// HighScore will also the same format used at location 0xCBEB: 6 ACII bytes followed by NULL
+// The file can hold as many games as we have space on the file system
+
+// Prototypes
+FRESULT highScoreOpenFile(void);
+HighScoreRetVal highScoreGet(const unsigned char * pGame, GameFileRecord * pGameRecord);
+HighScoreRetVal highScoreSetGameRecordToDefaults(const unsigned char * pGame, GameFileRecord * pGameRecord);
+void highScoreSave(unsigned char * pScore);
+HighScoreCompare highScoreCompare(const unsigned char * pScore1, const unsigned char * pScore2);
+HighScoreRetVal highScoreStore(GameFileRecord * pGameRecord);
+#endif // HIGHSCORE_H
+

--- a/code/veccart/main.c
+++ b/code/veccart/main.c
@@ -139,13 +139,20 @@ void loadRom(char *fn) {
 		// the active game high score record.  If the game doesn't exist,
 		// then setup record to default values for high score and add the name.
 		// A NULL as the second param will use the default active pointer.
-		if (highScoreGet((const unsigned char *)&romData[0x11], NULL) != HIGH_SCORE_SUCCESS)
-		{
+		HighScoreRetVal hs_ret_val = highScoreGet((const unsigned char *)&romData[0x11], NULL);
+		if (hs_ret_val != HIGH_SCORE_SUCCESS) {
+			xprintf("highScoreGet failure: %d, creating default high score for: %s\n", hs_ret_val, fn);
 			// Set the active game record to defaults and change name to the current
 			// game we are loading. This will prepare it to be stored once we
-			// acquire a newscore from the game ROM running.
-			highScoreSetGameRecordToDefaults((const unsigned char *)&romData[0x11], NULL);
+			// acquire a new high score from the game ROM running.
+			hs_ret_val = highScoreSetGameRecordToDefaults((const unsigned char *)&romData[0x11], NULL);
+			if (hs_ret_val != HIGH_SCORE_SUCCESS) {
+				xprintf("highScoreSetGameRecordToDefaults failure: %d\n", hs_ret_val);
+			}
+		} else {
+			xprintf("highScoreGet success\n");
 		}
+
 
 		// Store high score towards the end of the menu data
 		menuData[0x0ff0] = pActiveGameData->maxScore[0];
@@ -313,7 +320,7 @@ void loadSysOpt() {
 	if (size > 15) size = 15; // limited to 15 for now
 	for (int i = 0; i < size; i++) {
 		menuData[0xff0 + i] = sysData[addr + i];
-		xprintf("sysData[%x]=%u,checkDevMode=%d\n", addr + i, sysData[addr + i], checkDevMode);
+		// xprintf("sysData[%x]=%u,checkDevMode=%d\n", addr + i, sysData[addr + i], checkDevMode);
 	}
 }
 

--- a/code/veccart/main.h
+++ b/code/veccart/main.h
@@ -22,5 +22,6 @@ void ledsMagenta(void);
 void ledsOff(void);
 void loadSysOpt(void);
 void dumpMemory(void);
+void loadParmRam(void);
 
 #endif

--- a/code/veccart/main.h
+++ b/code/veccart/main.h
@@ -3,6 +3,7 @@
 
 void uart_output_func(unsigned char c);
 void loadRom(char *fn);
+void loadRomWithHighScore(char *fn, bool load_hs_mode);
 void loadStreamData(int addr, int len);
 void doUpDir(void);
 void doChangeDir(char* dirname);


### PR DESCRIPTION
### Problem

This PR is #56 rebased with fixes and improvements

### Solution

- PR #55 rebased on master
- whitespace fixes
- fixes a few pointer/size comparisons
- adds conditional highscore.c logging { #define DEBUG_HIGHSCORE (1) }
- makes high_score_flag readable from parmRam with new RPC ID 16, and speeds memory r/w for highscore
- Dev Mode (cart.bin) and Menu (multicart.bin) should not load a high score

### Steps to Test

Play a bunch of games... if when you lose all lives the high score is set, it should show at the top of the screen when you press reset to get back to the menu.  At that time a new high score record will be saved in `/hs.bin`.  Play a different game, reset, and play the previous game that the high score was saved for, and it should load up in the game when it starts.

### References

Implements #55 
Closes #56