### PR TITLE
Update Dockerfile distro to Arch w/ newer arm-gcc (10.1)

### DIFF
--- a/code/veccart/Dockerfile
+++ b/code/veccart/Dockerfile
@@ -1,17 +1,14 @@
-FROM ubuntu:18.04
-LABEL Description="A clone of the i2c-tiny-usb based upon STM32 and libopencm3"          
+FROM archlinux:20200605
+LABEL Description="STM32 and libopencm3"
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -y -q \
-    && apt-get install -y -q sudo make python git-core \
-    && apt-get install -y -q software-properties-common \
-    && add-apt-repository ppa:team-gcc-arm-embedded/ppa \
-    && apt-get update 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-arm-embedded
+RUN pacman -Syu --noconfirm \
+ && pacman -S make git python --noconfirm \
+ && pacman -S arm-none-eabi-gcc arm-none-eabi-binutils arm-none-eabi-newlib --noconfirm
 
 WORKDIR /build
 RUN git clone https://github.com/libopencm3/libopencm3.git \
     && cd libopencm3 \
-    && git checkout f7a952c41a815572622f137881af6160730a3768 \
-    && make
+    && git checkout 90753950bbe10e87b8caabfb0bd6e1d195bb24b8 \
+    && TARGETS=stm32/f4 make
 
 WORKDIR /build/veccart

--- a/code/veccart/Makefile
+++ b/code/veccart/Makefile
@@ -62,6 +62,7 @@ TOOLCHAIN_DIR=../libopencm3
 CFLAGS		+= -O3 -g -Wextra -Wshadow -Wimplicit-function-declaration -Wredundant-decls \
 		-Wmissing-prototypes -Wstrict-prototypes -fno-common -ffunction-sections -fdata-sections \
 		-MD -Wall -Wundef -I$(TOOLCHAIN_DIR)/include $(ARCH_FLAGS)
+ASFLAGS += $(ARCH_FLAGS)
 
 LDSCRIPT	= stm32f411rct6.ld
 #../libopencm3/lib/lib$(LIBNAME).ld


### PR DESCRIPTION
### Problem

Docker-based build system is out-of-date

### Solution

In order to get pre-packaged newer arm-none-eabi packages, use a rolling distro (Arch Linux)
Currently, this will install gcc 10.1

### Steps to Test

`make docker-build` builds a new container named `stm32-build`, which the makefile can use to build the vextreme firmware.

---

### Contributor License Agreement

I, `Bradon Kanyid`, agree to license my contributions to this project under the terms of the [GPL 3.0](https://www.gnu.org/licenses/gpl-3.0.html) or any later version.

>Please add your full legal name above, for this PR to be mergeable.  If you would prefer to sign a CLA via email, please request that.
