### PR TITLE
Rattboi/embedded multicart

### DIFF
--- a/code/veccart/.gitignore
+++ b/code/veccart/.gitignore
@@ -55,3 +55,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# generated filed for multicart menu pulled from other directory (don't want it checked in here)
+multicart.ld

--- a/code/veccart/Makefile
+++ b/code/veccart/Makefile
@@ -56,6 +56,7 @@ CC		= $(PREFIX)-gcc
 LD		= $(PREFIX)-gcc
 OBJCOPY	= $(PREFIX)-objcopy
 OBJDUMP	= $(PREFIX)-objdump
+
 # Uncomment this line if you want to use the installed (not local) library.
 #TOOLCHAIN_DIR = `dirname \`which $(CC)\``/../$(PREFIX)
 TOOLCHAIN_DIR=../libopencm3
@@ -96,6 +97,10 @@ docker-build: Dockerfile
 docker:
 	docker run --rm -t -v `pwd`:/build/veccart -u `id -u ${USER}`:`id -g ${USER}` stm32-build make images $(HW_VER_ARGS)
 
+bash:
+	docker run --rm -it -v `pwd`:/build/veccart -u `id -u ${USER}`:`id -g ${USER}` stm32-build bash
+
+
 images: $(BINARY).images
 flash: $(BINARY).flash
 
@@ -117,12 +122,20 @@ rom.o: rom.inc rom.c rom.h
 %.list: %.elf
 	$(VERBOSE)$(OBJDUMP) -S $(*).elf > $(*).list
 
-%.elf: $(OBJS) $(LDSCRIPT)
+%.elf: $(OBJS) $(LDSCRIPT) multicart.ld
 	$(LD) -o $(*).elf $(OBJS) $(LDFLAGS)
 	$(PREFIX)-size $(*).elf
 
 %.o: %.c Makefile
 	$(CC) $(CFLAGS) -o $@ -c $<
+
+multicart.bin:
+	make -C ../multicart/ docker-build
+	make -C ../multicart/
+	cp ../multicart/multicart.bin .
+
+multicart.ld: multicart.bin
+	cat $< | hexdump -v -e '"BYTE(0x" 1/1 "%02X" ")\n"' > $@
 
 clean:
 	rm -f $(OBJS)
@@ -132,9 +145,6 @@ clean:
 	rm -f *.srec
 	rm -f *.list
 	rm -rf *.d
-
-#%.flash: %.hex
-#	stm32flash -w "$(*).hex" -b 460800 -i -rts,dtr,-dtr -v -g 0x0 /dev/ttyUSB0
 
 %.flash: %.bin
 	dfu-util -a 0 -d 0483:df11 -s 0x08000000 -D $(*).bin

--- a/code/veccart/main.h
+++ b/code/veccart/main.h
@@ -2,8 +2,9 @@
 #define MAIN_H
 
 void uart_output_func(unsigned char c);
+void loadMenu(void);
 void loadRom(char *fn);
-void loadRomWithHighScore(char *fn, bool load_hs_mode);
+void loadRomWithHighScore(char *fn, bool load_hs_mode, bool use_embedded_menu);
 void loadStreamData(int addr, int len);
 void doUpDir(void);
 void doChangeDir(char* dirname);

--- a/code/veccart/stm32f411rct6.ld
+++ b/code/veccart/stm32f411rct6.ld
@@ -7,3 +7,17 @@ ram (rwx) : ORIGIN = 0x20000400, LENGTH = 127K
 }
 /* Include the common ld script. */
 INCLUDE cortex-m-generic.ld
+
+SECTIONS {
+    .text : {
+
+        /* ... */
+
+        multicart_start = .;
+        INCLUDE "multicart.ld" ;
+        multicart_end = .;
+
+       /* ... */
+    }
+}
+


### PR DESCRIPTION
### Problem

Should supply a built-in menu that is overrideable by a file on the flash filesystem

### Solution

This PR makes the latest built multicart an object that is linked in, and the new `loadMenu` code attempts to see if a menu file exists in the filesystem. If no, it will load the embedded menu instead.

### Steps to Test

1) Flash this firmware
2) Remove multicart.bin from flash over usb.

### References

---

### Contributor License Agreement

I, `Bradon Kanyid`, agree to license my contributions to this project under the terms of the [GPL 3.0](https://www.gnu.org/licenses/gpl-3.0.html) or any later version.

>Please add your full legal name above, for this PR to be mergeable.  If you would prefer to sign a CLA via email, please request that.
